### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# js-habitify
+# js-habitify-api
 
 Unofficial [Habitify](https://www.habitify.me/) API client for JavaScript.
 API Docs: https://docs.habitify.me/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "habitify",
+  "name": "habitify-api",
   "version": "0.0.0",
   "license": "MIT",
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",


### PR DESCRIPTION
npm package "habitify" already exists. https://www.npmjs.com/package/habitify?activeTab=readme
So I should rename the package.

"habitify-api"
