### PR TITLE
Improve scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
   "description": "API Wrapper for Habitify",
   "scripts": {
-    "build": "yarn build:lib",
-    "build:lib": "tsup src/*.ts --dts --format cjs,esm --minify --clean --sourcemap",
-    "dev:lib": "tsup src/*.ts --dts --format cjs,esm --minify --clean --sourcemap --watch --onSuccess 'node dist/index.js'",
+    "build": "\"$npm_execpath\" run build:lib",
+    "build:lib": "tsup src/**/*.ts --dts src/index.ts --format cjs,esm --minify --clean --sourcemap",
+    "dev:lib": "\"$npm_execpath\" run build:lib --watch --onSuccess 'node dist/index.js'",
     "test": "jest --coverage",
     "lint": "eslint --ext .ts src",
     "format": "prettier --write ."


### PR DESCRIPTION
- Make sure that TypeScript type definitions are properly generated
  - According to https://tsup.egoist.dev/#generate-declaration-file, `<entry>` was required, but it was missing. Fix it.
- Fix commands with duplicate definitions.
  - Change the path specification from `src/*.ts` to `src/**/*.ts` to include files in subdirectories.
  - Run `yarn` via `\"$npm_execpath\"` to make `yarn` and `npm` behave the same way.
