### PR TITLE
Make it possible to post and delete habit logs

### DIFF
--- a/src/__generated__/schema.JournalAPIResult.json
+++ b/src/__generated__/schema.JournalAPIResult.json
@@ -71,7 +71,14 @@
           }
         },
         "area": {
-          "$ref": "#/definitions/Area"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Area"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "created_date": {
           "$ref": "#/definitions/DateString"
@@ -100,11 +107,9 @@
         "log_method",
         "recurrence",
         "remind",
-        "area",
         "created_date",
         "priority",
         "status",
-        "progress",
         "habit_type"
       ],
       "additionalProperties": false
@@ -169,7 +174,7 @@
     },
     "Status": {
       "type": "string",
-      "enum": ["in_progress", "completed", "failed", "skipped"]
+      "enum": ["in_progress", "completed", "failed", "skipped", "none"]
     },
     "Progress": {
       "type": "object",

--- a/src/habitify.ts
+++ b/src/habitify.ts
@@ -7,6 +7,7 @@ import {
   LogsAPIResult,
   HabitAPIResult,
   HabitsAPIResult,
+  UnitType,
 } from './types'
 import {
   validateHabit,
@@ -135,5 +136,67 @@ export class Client {
   async fetchHabitById(habitId: string): Promise<HabitAPIResult> {
     const url = `${HABITIFY_API_HABITS_URL}/${habitId}`
     return await this.fetchWithValidation<HabitAPIResult>(url, validateHabit)
+  }
+
+  /**
+   * Post habit log to Habitify API.
+   * https://docs.habitify.me/core-resources/habits/logs
+   * @param habitId {string}
+   * @param unitType {UnitType} (default: 'rep')
+   * @param targetDate A subset of ISO 8601 format: https://docs.habitify.me/date-format (e.g. 2023-07-24T00:00:00+09:00) {DateString}
+   * @param value {number} (default: 1)
+   * @throws Error if post failed
+   * @returns void
+   */
+  async postHabitLog({
+    habitId,
+    unitType,
+    targetDate,
+    value,
+  }: {
+    habitId: string
+    unitType?: UnitType
+    targetDate: string
+    value?: number
+  }): Promise<void> {
+    const url = `${HABITIFY_API_LOGS_URL}/${habitId}`
+    const body = {
+      unit_type: unitType ?? 'rep',
+      value: value ?? 1,
+      target_date: targetDate,
+    }
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: this.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    })
+    if (!response.ok) {
+      throw new Error(`post failed: ${response.statusText}`)
+    }
+  }
+
+  /**
+   * Delete habit log from Habitify API.
+   */
+  async deleteHabitLog({
+    habitId,
+    logId,
+  }: {
+    habitId: string
+    logId: string
+  }): Promise<void> {
+    const url = `${HABITIFY_API_LOGS_URL}/${habitId}/${logId}`
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        Authorization: this.apiKey,
+      },
+    })
+    if (!response.ok) {
+      throw new Error(`delete failed: ${response.statusText}`)
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,11 +23,11 @@ export interface JournalContent {
   log_method: LogMethod
   recurrence: Recurrence
   remind: Remind[]
-  area: Area
+  area?: Area | null
   created_date: DateString
   priority: number
   status: Status
-  progress: Progress
+  progress?: Progress
   habit_type: number
 }
 
@@ -52,7 +52,7 @@ export interface Progress {
 }
 
 export type Remind = unknown // TODO
-export type Status = 'in_progress' | 'completed' | 'failed' | 'skipped'
+export type Status = 'in_progress' | 'completed' | 'failed' | 'skipped' | 'none'
 // https://docs.habitify.me/enum/time-of-day
 export type TimeOfDay = 'any_time' | 'morning' | 'afternoon' | 'evening'
 export type UnitType = 'rep' // https://docs.habitify.me/enum/unit-type#scalar


### PR DESCRIPTION
https://docs.habitify.me/core-resources/habits/logs#available-methods

- [x] POST /logs
- [x] DELETE /logs/:logId

```ts
const client = Client.getClientFromEnv()
await client.postHabitLog({
  habitId: '1234',
  targetDate: '2020-08-04T00:00:00+09:00',
})

await client.deleteHabitLog({
  habitId: '1234',
  logId: '5678',
})
```
