### PR TITLE
Run CI in serial

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>kitsuyui/renovate-config'],
+  // https://docs.renovatebot.com/configuration-options/#prhourlylimit
+  // 1 PR per hour to avoid conflicts with other PRs in test
+  prHourlyLimit: 1,
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  push:
   pull_request:
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,5 @@
 name: Spellcheck
 on:
-  - push
   - pull_request
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: test
 on:
-  - push
   - pull_request
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ jobs:
 
     continue-on-error: true
     strategy:
+      # Restrict concurrent runs to one per workflow run
+      # Because the test uses habitify data and it must be run sequentially
+      max-parallel: 1
       fail-fast: false
       matrix:
         node-version: [18.x, 20.x]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:lib": "tsup src/**/*.ts --dts src/index.ts --format cjs,esm --minify --clean --sourcemap",
     "build:schema": "node -r esbuild-register build-schema.ts && prettier --write src/__generated__/",
     "dev:lib": "\"$npm_execpath\" run build:lib --watch --onSuccess 'node dist/index.js'",
-    "test": "jest --coverage",
+    "test": "jest --coverage --maxWorkers=1",
     "lint": "eslint --ext .ts src",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
I use the actual Habitify API. Therefore, if you run the tests in parallel, conflicts will occur.
Ideally, I should fix the tests themselves so that they don't conflict.
However, I can't think of a reasonable way to do it now, so I can't run the tests in parallel.
(Habitify's API is only available on the paid plan. Therefore, I don't want to add test data to my Habitify account)
Therefore, we will change the CI to run in serial.
